### PR TITLE
Engine Improvements and ClueBotImproved

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Scores are average of seeds 0-99 and are out of 25.
 
 - DumbBot (1.56): Always plays the first card.
 - ClueBot (6.56): Plays clued cards and clues playable cards
+- ClueBotImproved (12.36): Avoids giving clues that have already been given and selects between color & number based on which touches fewer additional card.
+- ClueBotMk3 (12.01): Explores all possible clues to try and find the most optimal
 
 Cheating bots: These bots access their own hands.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Scores are average of seeds 0-99 and are out of 25.
 - ClueBotImproved (12.36): Avoids giving clues that have already been given and selects between color & number based on which touches fewer additional card.
 - ClueBotMk3 (12.01): Explores all possible clues to try and find the most optimal
 - ListenerBot (16.19): Listens to clues given by others (and itself) to try and avoid giving duplicate clues. 
+- ListenerBotMk2 (16.67): Improvements to clue giving w.r.t. ListenerBot. Still has discard problems.
 
 Cheating bots: These bots access their own hands.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Scores are average of seeds 0-99 and are out of 25.
 - ClueBot (6.56): Plays clued cards and clues playable cards
 - ClueBotImproved (12.36): Avoids giving clues that have already been given and selects between color & number based on which touches fewer additional card.
 - ClueBotMk3 (12.01): Explores all possible clues to try and find the most optimal
+- ListenerBot (16.19): Listens to clues given by others (and itself) to try and avoid giving duplicate clues. 
 
 Cheating bots: These bots access their own hands.
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ Scores are average of seeds 0-99 and are out of 25.
 - ClueBot (6.56): Plays clued cards and clues playable cards
 - ClueBotImproved (12.36): Avoids giving clues that have already been given and selects between color & number based on which touches fewer additional card.
 - ClueBotMk3 (12.01): Explores all possible clues to try and find the most optimal
-- ListenerBot (16.19): Listens to clues given by others (and itself) to try and avoid giving duplicate clues. 
-- ListenerBotMk2 (16.67): Improvements to clue giving w.r.t. ListenerBot. Still has discard problems.
+- ClueBotAdvanced (16.30) : Explores all possible clues and identifies all valid clues, then gives a clue to the player with the least information.
 
 Cheating bots: These bots access their own hands.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Scores are average of seeds 0-99 and are out of 25.
 - ClueBotImproved (12.36): Avoids giving clues that have already been given and selects between color & number based on which touches fewer additional card.
 - ClueBotMk3 (12.01): Explores all possible clues to try and find the most optimal
 - ClueBotAdvanced (16.30) : Explores all possible clues and identifies all valid clues, then gives a clue to the player with the least information.
+- LookaheadBot (16.38) : Predicts if other players will play on their turn and gives clues based on how those plays will change the possible playable cards.
 
 Cheating bots: These bots access their own hands.
 

--- a/bot.py
+++ b/bot.py
@@ -4,35 +4,20 @@ import logging
 from hanabi import Board, Clue, Discard, Play
 
 class BaseBot():
-    def __init__(self):
-        pass
+    def __init__(self, board: Board, index: int):
+        self.board = board
+        self.index = index
 
-    def play(self, board: Board) -> Turn:
+    def play(self) -> Turn:
         raise NotImplemented
 
     def reset(self):
         pass
 
-    # Common helper functions
-    @staticmethod
-    def is_playable(card: Card, board: Board) -> bool:
-        """can a card be played immediately?"""
-        return board.played_cards[card.color] == card.number - 1
-
-    @staticmethod
-    def is_discardable(card: Card, board: Board) -> bool:
-        """can a card be discarded? these cards are greyed out in the web version"""
-        return board.played_cards[card.color] >= card.number
-
-    @staticmethod
-    def is_unique(card: Card, board: Board) -> bool:
-        """does a card need to be saved? these cards have a red exclamation point in the web version"""
-        original_count = {5: 1, 4: 2, 3: 2, 2: 2, 1: 3}[card.number] # original number of copies of that card
-        return (original_count - board.discarded_cards.count(card)) == 1
 
 class DumbBot(BaseBot):
     """Dumb bot always plays the first card"""
-    def play(self, board: Board) -> Turn:
+    def play(self) -> Turn:
         return Play(0)
 
 class BasicCheatingBot(BaseBot):
@@ -42,14 +27,14 @@ class BasicCheatingBot(BaseBot):
 
     Its main problem is discarding 5s from the initial deal
     """
-    def play(self, board: Board) -> Turn:
-        hand = board._hands[board.current_player]
-        for i, card in zip(range(board.my_hand_size - 1, -1, -1), reversed(hand)):
+    def play(self) -> Turn:
+        hand = self.board._hands[self.board.current_player]
+        for i, card in zip(range(self.board.my_hand_size - 1, -1, -1), reversed(hand)):
 
-            if self.is_playable(card, board):
+            if self.board.is_playable(card):
                 return Play(i)
-        if board.clues == 0:
-            return Discard(board.my_hand_size - 1)
+        if self.board.clues == 0:
+            return Discard(self.board.my_hand_size - 1)
         else:
             return Clue(target=0, color="r") # Clue the next player red
 
@@ -58,31 +43,31 @@ class CheatingBot(BaseBot):
     Improves on BasicCheatingBot by looking at the card it's going to discard and picking safe discards
     Its weakness is probably getting unlucky with draws and running out of turns
     """
-    def play(self, board: Board) -> Turn:
-        hand = board._hands[board.current_player]
+    def play(self) -> Turn:
+        hand = self.board._hands[self.board.current_player]
 
         # Play any playable cards. Neither ascending or descending order seem to help
         for i, card in enumerate(hand):
-            if self.is_playable(card, board):
+            if self.board.is_playable(card):
                 return Play(i)
 
         # Clue if we're close to max clues
-        if board.clues > 6:
+        if self.board.clues > 6:
             return Clue(target=0, color="r")
 
         # Discard if we have freely discardable cards
         for i, card in enumerate(hand):
-            if self.is_discardable(card, board):
+            if self.board.is_discardable(card):
                 return Discard(i)
 
         # Clue if we have clues left
-        if board.clues > 0:
+        if self.board.clues > 0:
             return Clue(target=0, color="r")
 
         # Discard any cards that don't need to be saved
         hand.sort(key=lambda x: x.number, reverse=True) # this discards 4 > 3 > 2, but barely helps
         for i, card in enumerate(hand):
-            if not self.is_unique(card, board):
+            if not self.board.is_unique(card):
                 return Discard(i)
 
         # Last resort, discard
@@ -91,23 +76,23 @@ class CheatingBot(BaseBot):
 
 class ClueBot(BaseBot):
     """Clues playable cards"""
-    def play(self, board: Board) -> Turn:
+    def play(self) -> Turn:
         # Play clued cards
-        for i, is_clued in enumerate(board.my_hand_clues):
+        for i, is_clued in enumerate(self.board.my_hand_clues):
             if is_clued:
                 return Play(i)
 
         # If out of clues, discard last card (card will never be clued because we play clued cards in prev step)
-        if board.clues == 0:
-            return Discard(board.my_hand_size - 1)
+        if self.board.clues == 0:
+            return Discard(self.board.my_hand_size - 1)
 
         # Clue playable cards
-        for i, hand in enumerate(board.visible_hands):
+        for player_idx, hand in self.board.visible_hands:
             for j, card in enumerate(hand):
-                if self.is_playable(card, board):
-                    return Clue(target=i, color=card.color) # todo: pick the least ambiguous target
+                if self.board.is_playable(card):
+                    return Clue(target=player_idx, color=card.color) # todo: pick the least ambiguous target
 
         # Otherwise discard last card
-        if board.clues >= 7:
+        if self.board.clues >= 7:
             return Clue(target=0, color="r") # throwaway clue. this is technically not allowed
-        return Discard(board.my_hand_size - 1)
+        return Discard(self.board.my_hand_size - 1)

--- a/bot.py
+++ b/bot.py
@@ -305,3 +305,92 @@ class ClueBotAdvanced(BaseBot):
 
         # Couldn't Play. Couldn't Clue. Couldn't Discard. Nothing left to try. This is probably a strike.
         return Play(0)
+
+class LookaheadBot(BaseBot):
+    """
+    LookaheadBot will always try to play a card on its turn. Knowing this about itself, it
+    will assume other players will play on their turns and consider giving clues to cards
+    that will be playable after others have played. 
+
+    For sanity, this 'lookahead' process will only cover each other players next turn, since
+    other players could choose to give us information and we can't predict that. 
+
+    The average score for this bot is 16.38. Slightly better than ClueBotAdvanced.
+    """
+
+    def _is_hypothetical_playable(self, card: Card, played_cards: Dict[str][int]) -> bool:
+        return played_cards[card.color] == card.number-1
+
+    def play(self, board: Board) -> Turn:
+        # If we have a clued card, play it immediately. 
+        for i, card_info in reversed(list(enumerate(board.current_info))):
+            # Play cards from oldest to newest
+            if card_info.clued:
+                return Play(i)
+
+        # Grab a copy of the currently played cards
+        future_cards = {}
+        for color, number in board.played_cards.items():
+            future_cards[color] = number
+
+        # Give a clue, if we can
+        if board.clues > 0:
+            # Decide if a player will play on their turn
+            for player in board.other_players:
+                player_info = board.get_info(player)
+                player_hand = board.get_hand(player)
+
+                will_play = bool([info.clued for info in player_info].count(True))
+
+                if will_play:
+                    # Decide which card they will play, and add it to the hypothetical board state
+                    for i, card_info in reversed(list(enumerate(player_info))):
+                        # Play cards from oldest to newest
+                        if card_info.clued:
+                            # Add this card to the hypothetical board state
+                            card = player_hand[i]
+                            logging.debug(f"Player {player} will play card {i}: {card} on their turn")
+                            if self._is_hypothetical_playable(card, future_cards):
+                                future_cards[card.color] = card.number
+                            else:
+                                logging.debug(f"Player {player} is about to make a mistake!")
+                            break
+                else:
+                    # This player has no cards currently clued. See if we can give them a clue. 
+                    # Follow the rules set out in 'ClueBotAdvanced'
+                    clued_cards = ClueBotAdvanced.get_clued_cards(board)
+                    possible_clues = [Clue(player, number=number) for number in set(board.variant.CARD_NUMBERS)] + [Clue(player, color=color) for color in set(board.variant.CARD_COLORS)]
+
+                    for clue in possible_clues:
+                        clue_touched = board.cards_touched(clue)
+
+                        # A clue must touch at least one card
+                        if sum(clue_touched) == 0:
+                            continue
+
+                        # A clue must not touch any non-(hypothetically)-playable cards:
+                        if sum([(not self._is_hypothetical_playable(card, future_cards)) for idx, card in enumerate(player_hand) if clue_touched[idx]]) > 0:
+                            continue
+
+                        # A clue must not touch a card already clued in another players' hand:
+                        if sum([(card in clued_cards) for idx, card in enumerate(player_hand) if clue_touched[idx]]) > 0:
+                            continue
+
+                        # A clue must not touch multiple of the same card in the same hand:
+                        if max([player_hand.count(card) for idx, card in enumerate(player_hand) if clue_touched[idx]]) > 1:
+                            continue
+
+                        # If we've made it this far, give the clue:
+                        return(clue)
+
+                    logging.debug(f"Player {player} has no valid clues")
+
+        # In this case there are no clues to give. Discard.
+        if board.clues < board.MAX_CLUES:
+            # Oldest card. Any players would have been played already.
+            return Discard(board.current_hand_size-1)
+
+        # Couldn't Play. Couldn't Clue. Couldn't Discard. Nothing left to try. This is probably a strike.
+        return Play(0)
+       
+

--- a/bot.py
+++ b/bot.py
@@ -3,7 +3,7 @@ import logging
 
 from operator import and_, not_, or_, eq
 
-from hanabi import Board, CardInfo, Clue, Discard, Play, CARD_NUMBERS, CARD_COLORS, MAX_CLUES
+from hanabi import Board, CardInfo, Clue, Discard, Play
 
 class BaseBot():
     def __init__(self):
@@ -143,8 +143,7 @@ class ClueBotMk3(BaseBot):
 
     Average score is about 12 points. 
     """
-    @property
-    def chop(self) -> int:
+    def chop(self, board) -> int:
         """Return the index of the highest un-clued card"""
         non_clued_cards = [idx for idx, info in enumerate(board.current_info) if not info.clued]
         if len(non_clued_cards) == 0:
@@ -163,7 +162,7 @@ class ClueBotMk3(BaseBot):
 
         # If out of clues, discard last card (card will never be clued because we play clued cards in prev step)
         if board.clues == 0:
-            return Discard(self.chop)
+            return Discard(self.chop(board))
 
         good_clues = []
 
@@ -179,7 +178,7 @@ class ClueBotMk3(BaseBot):
 
             should_touch = list(map(and_, playable, not_clued))
 
-            possible_clues = [Clue(target, number=number) for number in set(CARD_NUMBERS)] + [Clue(target, color=color) for color in set(CARD_COLORS)]
+            possible_clues = [Clue(target, number=number) for number in set(board.variant.CARD_NUMBERS)] + [Clue(target, color=color) for color in set(board.variant.CARD_COLORS)]
 
             for clue in possible_clues:
                 would_touch = board.cards_touched(clue)
@@ -202,7 +201,7 @@ class ClueBotMk3(BaseBot):
             # Otherwise discard last card
             if board.clues >= 7:
                 return Clue(target=board.relative_player(1), color="r") # throwaway clue. this is technically not allowed
-            return Discard(self.chop)
+            return Discard(self.chop(board))
 
 class ListenerBot(BaseBot):
     """

--- a/bot.py
+++ b/bot.py
@@ -8,10 +8,18 @@ class BaseBot():
         self.board = board
         self.index = index
 
-    def play(self) -> Turn:
-        raise NotImplemented
+        self.reset()
 
     def reset(self):
+        """Executed once at the start of the game"""
+        pass
+
+    def play(self) -> Turn:
+        """Executed on my turn"""
+        raise NotImplemented
+
+    def listen(self, turn: Turn) -> None:
+        """Executed after every turn"""
         pass
 
 
@@ -36,7 +44,7 @@ class BasicCheatingBot(BaseBot):
         if self.board.clues == 0:
             return Discard(self.board.my_hand_size - 1)
         else:
-            return Clue(target=0, color="r") # Clue the next player red
+            return Clue(target=self.board.relative_player(1), color="r") # Clue the next player red
 
 class CheatingBot(BaseBot):
     """
@@ -53,7 +61,7 @@ class CheatingBot(BaseBot):
 
         # Clue if we're close to max clues
         if self.board.clues > 6:
-            return Clue(target=0, color="r")
+            return Clue(target=self.board.relative_player(1), color="r")
 
         # Discard if we have freely discardable cards
         for i, card in enumerate(hand):
@@ -62,7 +70,7 @@ class CheatingBot(BaseBot):
 
         # Clue if we have clues left
         if self.board.clues > 0:
-            return Clue(target=0, color="r")
+            return Clue(target=self.board.relative_player(1), color="r")
 
         # Discard any cards that don't need to be saved
         hand.sort(key=lambda x: x.number, reverse=True) # this discards 4 > 3 > 2, but barely helps
@@ -78,8 +86,8 @@ class ClueBot(BaseBot):
     """Clues playable cards"""
     def play(self) -> Turn:
         # Play clued cards
-        for i, is_clued in enumerate(self.board.my_hand_clues):
-            if is_clued:
+        for i, card_info in enumerate(self.board.current_information):
+            if card_info.clued:
                 return Play(i)
 
         # If out of clues, discard last card (card will never be clued because we play clued cards in prev step)
@@ -94,5 +102,5 @@ class ClueBot(BaseBot):
 
         # Otherwise discard last card
         if self.board.clues >= 7:
-            return Clue(target=0, color="r") # throwaway clue. this is technically not allowed
+            return Clue(target=self.board.relative_player(1), color="r") # throwaway clue. this is technically not allowed
         return Discard(self.board.my_hand_size - 1)

--- a/bot.py
+++ b/bot.py
@@ -43,7 +43,7 @@ class BasicCheatingBot(BaseBot):
     Its main problem is discarding 5s from the initial deal
     """
     def play(self, board: Board) -> Turn:
-        hand = board._hands[board.current_player()]
+        hand = board._hands[board.current_player]
         for i, card in zip(range(board.my_hand_size() - 1, -1, -1), reversed(hand)):
 
             if self.is_playable(card, board):
@@ -59,7 +59,7 @@ class CheatingBot(BaseBot):
     Its weakness is probably getting unlucky with draws and running out of turns
     """
     def play(self, board: Board) -> Turn:
-        hand = board._hands[board.current_player()]
+        hand = board._hands[board.current_player]
 
         # Play any playable cards. Neither ascending or descending order seem to help
         for i, card in enumerate(hand):

--- a/bot.py
+++ b/bot.py
@@ -44,12 +44,12 @@ class BasicCheatingBot(BaseBot):
     """
     def play(self, board: Board) -> Turn:
         hand = board._hands[board.current_player]
-        for i, card in zip(range(board.my_hand_size() - 1, -1, -1), reversed(hand)):
+        for i, card in zip(range(board.my_hand_size - 1, -1, -1), reversed(hand)):
 
             if self.is_playable(card, board):
                 return Play(i)
         if board.clues == 0:
-            return Discard(board.my_hand_size() - 1)
+            return Discard(board.my_hand_size - 1)
         else:
             return Clue(target=0, color="r") # Clue the next player red
 
@@ -93,16 +93,16 @@ class ClueBot(BaseBot):
     """Clues playable cards"""
     def play(self, board: Board) -> Turn:
         # Play clued cards
-        for i, is_clued in enumerate(board.my_hand_clues()):
+        for i, is_clued in enumerate(board.my_hand_clues):
             if is_clued:
                 return Play(i)
 
         # If out of clues, discard last card (card will never be clued because we play clued cards in prev step)
         if board.clues == 0:
-            return Discard(board.my_hand_size() - 1)
+            return Discard(board.my_hand_size - 1)
 
         # Clue playable cards
-        for i, hand in enumerate(board.visible_hands()):
+        for i, hand in enumerate(board.visible_hands):
             for j, card in enumerate(hand):
                 if self.is_playable(card, board):
                     return Clue(target=i, color=card.color) # todo: pick the least ambiguous target
@@ -110,4 +110,4 @@ class ClueBot(BaseBot):
         # Otherwise discard last card
         if board.clues >= 7:
             return Clue(target=0, color="r") # throwaway clue. this is technically not allowed
-        return Discard(board.my_hand_size() - 1)
+        return Discard(board.my_hand_size - 1)

--- a/bot.py
+++ b/bot.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 import logging
 
-from hanabi import Board, CardInformation, Clue, Discard, Play
+from operator import and_, not_, or_, eq
+
+from hanabi import Board, CardInformation, Clue, Discard, Play, CARD_NUMBERS, CARD_COLORS
 
 class BaseBot():
     def __init__(self, board: Board, index: int):
@@ -136,5 +138,70 @@ class ClueBotImproved(BaseBot):
         if self.board.clues >= 7:
             return Clue(target=self.board.relative_player(1), color="r") # throwaway clue. this is technically not allowed
         return Discard(self.board.my_hand_size - 1)
-
     
+class ClueBotMk3(BaseBot):
+    """More nuanced cluing and discarding"""
+    @property
+    def chop(self) -> int:
+        """Return the index of the highest un-clued card"""
+        non_clued_cards = [idx for idx, info in enumerate(self.board.current_information) if not info.clued]
+        if len(non_clued_cards) == 0:
+            chop = 0
+        else:
+            chop = max(non_clued_cards)
+        logging.debug(f"Discarding card from position {chop}")
+        return chop
+
+    def cards_touched(self, clue: Clue) -> List[bool]:
+        """Simulate a clue on a hand to check which cards are touched"""
+        hand = self.board.player_hand(clue.target)
+        if clue.number:
+            return [card.number == clue.number for card in hand]
+        elif clue.color:
+            return [card.color == clue.color for card in hand]
+
+    def play(self) -> Turn:
+        # Play clued cards
+        for i, card_info in enumerate(self.board.current_information):
+            # Play cards from right to left
+            if card_info.clued:
+                return Play(i)
+
+        # If out of clues, discard last card (card will never be clued because we play clued cards in prev step)
+        if self.board.clues == 0:
+            return Discard(self.chop)
+
+        good_clues = []
+
+        # Scan all possible clues:
+        for player_offset in range(1,self.board.num_players):
+            target = self.board.relative_player(player_offset)
+             # The hand that this potential clue would target
+            hand = self.board.player_hand(target)
+            # The cards that are immediately playable from this hand
+            playable = list(map(self.board.is_playable, hand))
+
+            should_touch = playable
+
+            possible_clues = [Clue(target, number=number) for number in set(CARD_NUMBERS)] + [Clue(target, color=color) for color in set(CARD_COLORS)]
+
+            for clue in possible_clues:
+                would_touch = self.cards_touched(clue)
+                num_touch = sum(would_touch)
+
+                # Check that this clue touches only playable cards
+                if sum(map(eq, should_touch, would_touch)) == self.board.cards_per_player and num_touch != 0:
+                    logging.debug(f"Found good clue: {clue}: {num_touch} cards")
+                    good_clues.append((clue, num_touch))
+
+
+        if len(good_clues) > 0:
+            # Now that we have a list of good clues (clues that touch only immediately playable cards), we pick which one 
+            # to give based on which player needs information the most:
+            good_clues.sort(key=lambda x: x[1])
+            return good_clues[0][0]
+        else:
+            # Otherwise discard last card
+            if self.board.clues >= 7:
+                return Clue(target=self.board.relative_player(1), color="r") # throwaway clue. this is technically not allowed
+            return Discard(self.chop)

--- a/hanabi.py
+++ b/hanabi.py
@@ -1,13 +1,12 @@
 from dataclasses import dataclass, field
 import logging
 from textwrap import dedent, indent
-from typing import List, Union, Tuple
+from typing import List, Union, Tuple, Set
 import random
 
 CARD_COLORS = ["r", "y", "g", "b", "p"]
 CARD_NUMBERS = [1, 1, 1, 2, 2, 3, 3, 4, 4, 5]
-CARD_NUMBERS_UNIQUE = list(set(CARD_NUMBERS))
-CARD_COUNT = {i: CARD_NUMBERS.count(i) for i in CARD_NUMBERS_UNIQUE}
+CARD_COUNT = {i: CARD_NUMBERS.count(i) for i in set(CARD_NUMBERS)}
 
 MAX_CLUES = 8
 
@@ -41,8 +40,8 @@ class Card:
 @dataclass
 class CardInformation:
     # This syntax is required to initialize each new CardInformation object with a COPY of the constant values
-    color: List[str] = field(default_factory=lambda: list(CARD_COLORS))
-    number: List[int] = field(default_factory=lambda: list(CARD_NUMBERS_UNIQUE))
+    color: Set[str] = field(default_factory=lambda: set(CARD_COLORS))
+    number: Set[int] = field(default_factory=lambda: set(CARD_NUMBERS))
     clued: bool = False
 
     def __str__(self):
@@ -148,20 +147,18 @@ class Board:
             if turn.color:
                 if card.color == turn.color:
                     self.information[target][idx].color.clear()
-                    self.information[target][idx].color.append(turn.color)
+                    self.information[target][idx].color.add(turn.color)
                     self.information[target][idx].clued = True
                 else:
-                    if turn.color in self.information[target][idx].color:
-                        self.information[target][idx].color.remove(turn.color)
+                    self.information[target][idx].color.discard(turn.color)
 
             if turn.number:
                 if card.number == turn.number:
                     self.information[target][idx].number.clear()
-                    self.information[target][idx].number.append(turn.number)
+                    self.information[target][idx].number.add(turn.number)
                     self.information[target][idx].clued = True
                 else:
-                    if turn.number in self.information[target][idx].number:
-                        self.information[target][idx].number.remove(turn.number)
+                    self.information[target][idx].number.discard(turn.number)
         logging.info(f"Player {target} New Information: {[str(x) for x in self.information[target]]}")
 
         self.clues -= 1

--- a/hanabi.py
+++ b/hanabi.py
@@ -38,8 +38,8 @@ class Card:
         return f"{self.color}{self.number}"
 
 @dataclass
-class CardInformation:
-    # This syntax is required to initialize each new CardInformation object with a COPY of the constant values
+class CardInfo:
+    # This syntax is required to initialize each new CardInfo object with a COPY of the constant values
     color: Set[str] = field(default_factory=lambda: set(CARD_COLORS))
     number: Set[int] = field(default_factory=lambda: set(CARD_NUMBERS))
     clued: bool = False
@@ -65,33 +65,27 @@ class Board:
         self.turns_left: Optional[int] = None # None until the deck is exhausted, then counts down to 0
         self.strikes = 0
         self.clues = MAX_CLUES
-        self.information: List[List[CardInformation]] = [[] for _ in range(self.num_players)]
 
         ### Hidden attributes. DO NOT ACCESS THESE ATTRIBUTES IN YOUR BOT ###
+        self._card_info: List[List[CardInfo]] = [[] for _ in range(self.num_players)]
         self._deck: List[Card] = [Card(c, n) for c in CARD_COLORS for n in CARD_NUMBERS]
         random.seed(seed)
         random.shuffle(self._deck)
 
         self._hands: List[List[Card]] = [[] for i in range(self.num_players)]
         for i in range(self.num_players):
-            for j in range(self.cards_per_player):
+            for j in range(self.initial_cards_per_player):
                 self._draw_card(i)
 
         # History
         self.turns: List[Turn] = [] # History of turns. For debugging only I think
 
-
+    """
+    Global game properties
+    """
     @property
-    def cards_per_player(self):
+    def initial_cards_per_player(self):
         return 5 if self.num_players < 3 else 4
-
-    @property
-    def current_player(self) -> int:
-        return (self.turn_index + self.starting_player) % self.num_players
-
-    @property
-    def other_players(self) -> Set[int]:
-        return set(range(self.num_players)).difference(set([self.current_player]))
 
     @property
     def game_over(self) -> bool:
@@ -101,133 +95,44 @@ class Board:
     def score(self) -> int:
         return sum(self.played_cards.values())
 
+    """
+    Properties for information about players or their cards
+    """
     @property
-    def _current_hand(self) -> List[Card]:
-        return self._hands[self.current_player]
+    def current_player(self) -> int:
+        return (self.turn_index + self.starting_player) % self.num_players
 
     @property
-    def current_information(self) -> List[CardInformation]:
-        return self.information[self.current_player]
+    def other_players(self) -> Set[int]:
+        """Returns an iterator through the other player's indices in relative turn order"""
+        players = list(range(self.num_players))
+        return players[self.current_player+1:] + players[:self.current_player]
+
+    @property
+    def current_info(self) -> List[CardInfo]:
+        return self.get_info(self.current_player)
 
     @property
     def visible_hands(self) -> List[Tuple[int, List[Card]]]: 
         """Other players' hands in turn-order with respect to the current player"""
-        tmp = list(enumerate(self._hands))
-        return tmp[self.current_player + 1:] + tmp[:self.current_player]
+        return [(player, self.get_hand(player)) for player in self.other_players]
 
     @property
-    def my_hand_size(self) -> int:
+    def current_hand_size(self) -> int:
         """How many cards are in my hand"""
         return len(self._current_hand)
 
-    def player_hand(self, index: int) -> List[Card]:
-        if index == self.current_player:
+    def get_hand(self, player: int) -> List[Card]:
+        if player == self.current_player:
             raise InvalidMove("cannot look at own hand")
-        return self._hands[index]
+        return self._hands[player]
 
-    def evaluate(self, turn: Turn):
-        if isinstance(turn, Clue):
-            self._clue_turn(turn)
-        elif isinstance(turn, Play):
-            self._play_turn(turn)
-        elif isinstance(turn, Discard):
-            self._discard_turn(turn)
-        else:
-            raise InvalidMove("invalid turn", turn)
+    def get_info(self, player: int) -> List[CardInfo]:
+        return self._card_info[player]
 
-        if self.turns_left is not None:
-            self.turns_left -= 1
-            
-        self.turns.append(turn)
-        self.turn_index += 1
-
-    def _clue_turn(self, turn: Clue):
-        target = turn.target
-        logging.info(f"Player {self.current_player} clued player {target} {turn.color or turn.number}")
-
-        if target == self.current_player:
-            raise InvalidMove("cannot clue self")
-        if self.clues == 0:
-            raise InvalidMove("no clues available")
-
-        # Update Information
-        logging.info(f"Player {target} Old Information: {[str(x) for x in self.information[target]]}")
-        for idx, card in enumerate(self._hands[target]):
-            if turn.color:
-                if card.color == turn.color:
-                    self.information[target][idx].color.clear()
-                    self.information[target][idx].color.add(turn.color)
-                    self.information[target][idx].clued = True
-                else:
-                    self.information[target][idx].color.discard(turn.color)
-
-            if turn.number:
-                if card.number == turn.number:
-                    self.information[target][idx].number.clear()
-                    self.information[target][idx].number.add(turn.number)
-                    self.information[target][idx].clued = True
-                else:
-                    self.information[target][idx].number.discard(turn.number)
-        logging.info(f"Player {target} New Information: {[str(x) for x in self.information[target]]}")
-
-        self.clues -= 1
-
-    def _play_turn(self, turn: Play):
-        played_card = self._current_hand.pop(turn.index)
-
-        if self.played_cards[played_card.color] == played_card.number - 1:
-            logging.info(f"Player {self.current_player} played from slot {turn.index}, {str(played_card)} successfully")
-            self.played_cards[played_card.color] += 1
-
-            if played_card.number == 5:
-                self.clues += 1
-                self.clues = max(self.clues, MAX_CLUES)
-        else:
-            logging.info(f"Player {self.current_player} tried to play from slot {turn.index}, {str(played_card)}")
-            self.discarded_cards.append(played_card)
-            self.strikes += 1
-
-        # Update information
-        logging.info(f"Player {self.current_player} Old Information: {[str(x) for x in self.current_information]}")
-        self.current_information.pop(turn.index)
-
-        self._draw_card()
-
-        logging.info(f"Player {self.current_player} New Information: {[str(x) for x in self.current_information]}")
-
-    def _discard_turn(self, turn: Discard):
-        if self.clues == MAX_CLUES:
-            logging.warning("Cannot discard at max clues")
-            raise InvalidMove("cannot discard at max clues")
-        discarded_card = self._current_hand.pop(turn.index)
-        logging.info(f"Player {self.current_player} discarded the card in slot {turn.index}, {str(discarded_card)}")
-        self.discarded_cards.append(discarded_card)
-
-        # Update information
-        logging.info(f"Player {self.current_player} Old Information: {[str(x) for x in self.current_information]}")
-        self.current_information.pop(turn.index)
-
-        self._draw_card()
-
-        logging.info(f"Player {self.current_player} New Information: {[str(x) for x in self.current_information]}")
-
-        self.clues += 1
-
-    def _draw_card(self, index=None):
-        """Draw a card for the `index`th player or the current player"""
-
-        if self._deck:
-            new_card = self._deck.pop()
-            player = index if index is not None else self.current_player
-            self._hands[player].insert(0, new_card)
-            self.information[player].insert(0, CardInformation())
-        else:
-            if self.turns_left is None:
-                self.turns_left = self.num_players + 1
-
-    #
-    # Common helper functions
-    #
+    """
+    Common helper functions
+    """
     def is_playable(self, card: Card) -> bool:
         """can a card be played immediately?"""
         return self.played_cards[card.color] == card.number - 1
@@ -244,6 +149,115 @@ class Board:
         """Returns the absolute index of a player relative to the current player 
            i.e. +1 for the next player, 0 for the current player, -1 for the previous player"""
         return (self.current_player + idx) % self.num_players
+
+    def evaluate(self, turn: Turn):
+        """Processes the results of each players' turn"""
+        if isinstance(turn, Clue):
+            self._clue_turn(turn)
+        elif isinstance(turn, Play):
+            self._play_turn(turn)
+        elif isinstance(turn, Discard):
+            self._discard_turn(turn)
+        else:
+            raise InvalidMove("invalid turn", turn)
+
+        if self.turns_left is not None:
+            self.turns_left -= 1
+            
+        self.turns.append(turn)
+        self.turn_index += 1
+
+    #
+    # Private Methods
+    #
+    @property
+    def _current_hand(self) -> List[Card]:
+        """Bots should NOT access this property"""
+        return self._hands[self.current_player]
+
+    def _clue_turn(self, clue: Clue):
+        target = clue.target
+        logging.info(f"Player {self.current_player} clued player {target} {clue.color or clue.number}")
+
+        if target == self.current_player:
+            raise InvalidMove("cannot clue self")
+        if self.clues == 0:
+            raise InvalidMove("no clues available")
+
+        # Update Information
+        logging.info(f"Player {target} Old Information: {[str(x) for x in self._card_info[target]]}")
+        for idx, card in enumerate(self._hands[target]):
+            if clue.color:
+                if card.color == clue.color:
+                    self._card_info[target][idx].color.clear()
+                    self._card_info[target][idx].color.add(clue.color)
+                    self._card_info[target][idx].clued = True
+                else:
+                    self._card_info[target][idx].color.discard(clue.color)
+
+            if clue.number:
+                if card.number == clue.number:
+                    self._card_info[target][idx].number.clear()
+                    self._card_info[target][idx].number.add(clue.number)
+                    self._card_info[target][idx].clued = True
+                else:
+                    self._card_info[target][idx].number.discard(clue.number)
+        logging.info(f"Player {target} New Information: {[str(x) for x in self._card_info[target]]}")
+
+        self.clues -= 1
+
+    def _play_turn(self, card: Play):
+        played_card = self._current_hand.pop(card.index)
+
+        if self.played_cards[played_card.color] == played_card.number - 1:
+            logging.info(f"Player {self.current_player} played from slot {card.index}, {str(played_card)} successfully")
+            self.played_cards[played_card.color] += 1
+
+            if played_card.number == 5:
+                self.clues += 1
+                self.clues = max(self.clues, MAX_CLUES)
+        else:
+            logging.info(f"Player {self.current_player} tried to play from slot {card.index}, {str(played_card)}")
+            self.discarded_cards.append(played_card)
+            self.strikes += 1
+
+        # Update information
+        logging.info(f"Player {self.current_player} Old Information: {[str(x) for x in self.current_info]}")
+        self.current_info.pop(card.index)
+
+        self._draw_card()
+
+        logging.info(f"Player {self.current_player} New Information: {[str(x) for x in self.current_info]}")
+
+    def _discard_turn(self, card: Discard):
+        if self.clues == MAX_CLUES:
+            logging.warning("Cannot discard at max clues")
+            raise InvalidMove("cannot discard at max clues")
+        discarded_card = self._current_hand.pop(card.index)
+        logging.info(f"Player {self.current_player} discarded the card in slot {card.index}, {str(discarded_card)}")
+        self.discarded_cards.append(discarded_card)
+
+        # Update information
+        logging.info(f"Player {self.current_player} Old Information: {[str(x) for x in self.current_info]}")
+        self.current_info.pop(card.index)
+
+        self._draw_card()
+
+        logging.info(f"Player {self.current_player} New Information: {[str(x) for x in self.current_info]}")
+
+        self.clues += 1
+
+    def _draw_card(self, index=None):
+        """Draw a card for the `index`th player or the current player"""
+
+        if self._deck:
+            new_card = self._deck.pop()
+            player = index if index is not None else self.current_player
+            self._hands[player].insert(0, new_card)
+            self._card_info[player].insert(0, CardInfo())
+        else:
+            if self.turns_left is None:
+                self.turns_left = self.num_players + 1
 
     def __str__(self):
         newline = "\n"

--- a/hanabi.py
+++ b/hanabi.py
@@ -68,6 +68,29 @@ class Board:
     def current_player(self):
         return (self.turn_index + self.starting_player) % self.num_players
 
+    @property
+    def game_over(self) -> bool:
+        return self.strikes == 3 or all(v == 5 for v in self.played_cards.values()) or self.turns_left == 0
+
+    @property
+    def score(self) -> int:
+        return sum(self.played_cards.values())
+
+    @property
+    def visible_hands(self) -> List[List[Card]]:
+        """Other players' hands from the perspective of the current player"""
+        return self._hands[self.current_player + 1:] + self._hands[:self.current_player]
+
+    @property
+    def my_hand_clues(self) -> List[bool]:
+        """Which cards in my hand are clued"""
+        return [card.clued for card in self._hands[self.current_player]]
+
+    @property
+    def my_hand_size(self) -> int:
+        """How many cards are in my hand"""
+        return len(self._hands[self.current_player])
+
     def evaluate(self, turn: Turn):
         hand = self._hands[self.current_player]
 
@@ -131,30 +154,12 @@ class Board:
             if self.turns_left is None:
                 self.turns_left = self.num_players + 1
 
-    def is_game_over(self) -> bool:
-        return self.strikes == 3 or all(v == 5 for v in self.played_cards.values()) or self.turns_left == 0
-
-    def score(self) -> int:
-        return sum(self.played_cards.values())
-
-    def visible_hands(self) -> List[List[Card]]:
-        """Other players' hands from the perspective of the current player"""
-        return self._hands[self.current_player + 1:] + self._hands[:self.current_player]
-
-    def my_hand_clues(self) -> List[bool]:
-        """Which cards in my hand are clued"""
-        return [card.clued for card in self._hands[self.current_player]]
-
-    def my_hand_size(self) -> int:
-        """How many cards are in my hand"""
-        return len(self._hands[self.current_player])
-
     def __str__(self):
         newline = "\n"
         return dedent(f"""
         ================ Game at turn {self.turn_index} ===================
 
-        Played cards ({self.score()} / 25):
+        Played cards ({self.score} / 25):
             {self.played_cards}
 
         Hands:{newline}{indent(newline.join(" ".join(map(str, hand)) + (" <- current" if i == self.current_player else "") for i, hand in enumerate(self._hands)), " " * 12)}

--- a/hanabi.py
+++ b/hanabi.py
@@ -185,7 +185,7 @@ class Board:
             raise InvalidMove("no clues available")
 
         # Update Information
-        logging.info(f"Player {target} Old Information: {[str(x) for x in self._card_info[target]]}")
+        logging.debug(f"Player {target} Old Information: {[str(x) for x in self._card_info[target]]}")
         for idx, card in enumerate(self._hands[target]):
             if clue.color:
                 if card.color == clue.color:
@@ -202,7 +202,7 @@ class Board:
                     self._card_info[target][idx].clued = True
                 else:
                     self._card_info[target][idx].number.discard(clue.number)
-        logging.info(f"Player {target} New Information: {[str(x) for x in self._card_info[target]]}")
+        logging.debug(f"Player {target} New Information: {[str(x) for x in self._card_info[target]]}")
 
         self.clues -= 1
 
@@ -222,12 +222,12 @@ class Board:
             self.strikes += 1
 
         # Update information
-        logging.info(f"Player {self.current_player} Old Information: {[str(x) for x in self.current_info]}")
+        logging.debug(f"Player {self.current_player} Old Information: {[str(x) for x in self.current_info]}")
         self.current_info.pop(card.index)
 
         self._draw_card()
 
-        logging.info(f"Player {self.current_player} New Information: {[str(x) for x in self.current_info]}")
+        logging.debug(f"Player {self.current_player} New Information: {[str(x) for x in self.current_info]}")
 
     def _discard_turn(self, card: Discard):
         if self.clues == MAX_CLUES:
@@ -238,12 +238,12 @@ class Board:
         self.discarded_cards.append(discarded_card)
 
         # Update information
-        logging.info(f"Player {self.current_player} Old Information: {[str(x) for x in self.current_info]}")
+        logging.debug(f"Player {self.current_player} Old Information: {[str(x) for x in self.current_info]}")
         self.current_info.pop(card.index)
 
         self._draw_card()
 
-        logging.info(f"Player {self.current_player} New Information: {[str(x) for x in self.current_info]}")
+        logging.debug(f"Player {self.current_player} New Information: {[str(x) for x in self.current_info]}")
 
         self.clues += 1
 

--- a/hanabi.py
+++ b/hanabi.py
@@ -1,8 +1,15 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import logging
 from textwrap import dedent, indent
-from typing import List, Union
+from typing import List, Union, Tuple
 import random
+
+CARD_COLORS = ["r", "y", "g", "b", "p"]
+CARD_NUMBERS = [1, 1, 1, 2, 2, 3, 3, 4, 4, 5]
+CARD_NUMBERS_UNIQUE = list(set(CARD_NUMBERS))
+CARD_COUNT = {i: CARD_NUMBERS.count(i) for i in CARD_NUMBERS_UNIQUE}
+
+MAX_CLUES = 8
 
 # Turn
 @dataclass
@@ -27,10 +34,19 @@ Turn = Union[Clue, Discard, Play]
 class Card:
     color: str
     number: int
+
+    def __str__(self):
+        return f"{self.color}{self.number}"
+
+@dataclass
+class CardInformation:
+    # This syntax is required to initialize each new CardInformation object with a COPY of the constant values
+    color: List[str] = field(default_factory=lambda: list(CARD_COLORS))
+    number: List[int] = field(default_factory=lambda: list(CARD_NUMBERS_UNIQUE))
     clued: bool = False
 
     def __str__(self):
-        return f"{self.color}{self.number}{'*' if self.clued else ' '}"
+        return ("*" if self.clued else "") + "".join(map(str, self.color)) + "".join(map(str, self.number))
     
 class InvalidMove(Exception):
     pass
@@ -43,14 +59,15 @@ class Board:
 
     def reset(self, seed=None, starting_player=0):
         ### Hidden attributes. DO NOT ACCESS THESE ATTRIBUTES IN YOUR BOT ###
-        self._deck: List[Card] = [Card(c, n) for c in "rygbp" for n in (1, 1, 1, 2, 2, 3, 3, 4, 4, 5)]
+        self._deck: List[Card] = [Card(c, n) for c in CARD_COLORS for n in CARD_NUMBERS]
         random.seed(seed)
         random.shuffle(self._deck)
 
         self._hands: List[List[Card]] = [[] for i in range(self.num_players)]
         for i in range(self.num_players):
-            for j in range(4): # TODO: make number of cards per player dynamic
+            for j in range(self.cards_per_player):
                 self._draw_card(i)
+
 
         # History
         self.turns: List[Turn] = [] # History of turns. For debugging only I think
@@ -62,7 +79,12 @@ class Board:
         self.turn_index = 0
         self.turns_left: Optional[int] = None # None until the deck is exhausted, then counts down to 0
         self.strikes = 0
-        self.clues = 8
+        self.clues = MAX_CLUES
+        self.information: List[List[CardInformation]] = [[CardInformation() for _ in range(self.cards_per_player)] for _ in range(self.num_players)]
+
+    @property
+    def cards_per_player(self):
+        return 5 if self.num_players < 3 else 4
 
     @property
     def current_player(self) -> int:
@@ -77,64 +99,31 @@ class Board:
         return sum(self.played_cards.values())
 
     @property
-    def visible_hands(self) -> List[(int, List[Card])]:
-        """Other players' hands from the perspective of the current player"""
-        tmp = enumerate(self._hands)
-        return tmp[self.current_player + 1:] + tmp[:self.current_player]
+    def _current_hand(self) -> List[Card]:
+        return self._hands[self.current_player]
 
     @property
-    def my_hand_clues(self) -> List[bool]:
-        """Which cards in my hand are clued"""
-        return [card.clued for card in self._hands[self.current_player]]
+    def current_information(self) -> List[CardInformation]:
+        return self.information[self.current_player]
+
+    @property
+    def visible_hands(self) -> List[Tuple[int, List[Card]]]: 
+        """Other players' hands in turn-order with respect to the current player"""
+        tmp = list(enumerate(self._hands))
+        return tmp[self.current_player + 1:] + tmp[:self.current_player]
 
     @property
     def my_hand_size(self) -> int:
         """How many cards are in my hand"""
-        return len(self._hands[self.current_player])
+        return len(self._current_hand)
 
     def evaluate(self, turn: Turn):
-        hand = self._hands[self.current_player]
-
         if isinstance(turn, Clue):
-            target = (self.current_player + turn.target + 1) % self.num_players
-            logging.info(f"Player {self.current_player} clued player {target} {turn.color or turn.number}")
-
-            if target == self.current_player:
-                raise InvalidMove("cannot clue self")
-            if self.clues == 0:
-                raise InvalidMove("no clues available")
-
-            for card in self._hands[target]:
-                if card.number == turn.number or card.color == turn.color:
-                    card.clued = True
-            # TODO: A Clue must clue a card. For duck, negative clues are worthless though so not going to implement.
-
-            self.clues -= 1
+            self._clue_turn(turn)
         elif isinstance(turn, Play):
-            played_card = hand.pop(turn.index)
-
-            if self.played_cards[played_card.color] == played_card.number - 1:
-                logging.info(f"Player {self.current_player} played from slot {turn.index}, {str(played_card)} successfully")
-                self.played_cards[played_card.color] += 1
-
-                if played_card.number == 5:
-                    self.clues += 1
-                    self.clues = max(self.clues, 8)
-            else:
-                logging.info(f"Player {self.current_player} tried to play from slot {turn.index}, {str(played_card)}")
-                self.discarded_cards.append(played_card)
-                self.strikes += 1
-
-            self._draw_card()
+            self._play_turn(turn)
         elif isinstance(turn, Discard):
-            if self.clues == 8:
-                logging.warning("Cannot discard at max clues")
-                raise InvalidMove("cannot discard at max clues")
-            discarded_card = hand.pop(turn.index)
-            logging.info(f"Player {self.current_player} discarded the card in slot {turn.index}, {str(discarded_card)}")
-            self.discarded_cards.append(discarded_card)
-            self._draw_card()
-            self.clues += 1
+            self._discard_turn(turn)
         else:
             raise InvalidMove("invalid turn", turn)
 
@@ -143,6 +132,79 @@ class Board:
             
         self.turns.append(turn)
         self.turn_index += 1
+
+    def _clue_turn(self, turn: Clue):
+        target = turn.target
+        logging.info(f"Player {self.current_player} clued player {target} {turn.color or turn.number}")
+
+        if target == self.current_player:
+            raise InvalidMove("cannot clue self")
+        if self.clues == 0:
+            raise InvalidMove("no clues available")
+
+        # Update Information
+        logging.info(f"Player {target} Old Information: {[str(x) for x in self.information[target]]}")
+        for idx, card in enumerate(self._hands[target]):
+            if turn.color:
+                if card.color == turn.color:
+                    self.information[target][idx].color.clear()
+                    self.information[target][idx].color.append(turn.color)
+                    self.information[target][idx].clued = True
+                else:
+                    if turn.color in self.information[target][idx].color:
+                        self.information[target][idx].color.remove(turn.color)
+
+            if turn.number:
+                if card.number == turn.number:
+                    self.information[target][idx].number.clear()
+                    self.information[target][idx].number.append(turn.number)
+                    self.information[target][idx].clued = True
+                else:
+                    if turn.number in self.information[target][idx].number:
+                        self.information[target][idx].number.remove(turn.number)
+        logging.info(f"Player {target} New Information: {[str(x) for x in self.information[target]]}")
+
+        self.clues -= 1
+
+    def _play_turn(self, turn: Play):
+        played_card = self._current_hand.pop(turn.index)
+
+        if self.played_cards[played_card.color] == played_card.number - 1:
+            logging.info(f"Player {self.current_player} played from slot {turn.index}, {str(played_card)} successfully")
+            self.played_cards[played_card.color] += 1
+
+            if played_card.number == 5:
+                self.clues += 1
+                self.clues = max(self.clues, MAX_CLUES)
+        else:
+            logging.info(f"Player {self.current_player} tried to play from slot {turn.index}, {str(played_card)}")
+            self.discarded_cards.append(played_card)
+            self.strikes += 1
+
+        self._draw_card()
+
+        # Update information
+        logging.info(f"Player {self.current_player} Old Information: {[str(x) for x in self.current_information]}")
+        self.current_information.pop(turn.index)
+        self.current_information.insert(0, CardInformation())
+        logging.info(f"Player {self.current_player} New Information: {[str(x) for x in self.current_information]}")
+
+    def _discard_turn(self, turn: Discard):
+        if self.clues == MAX_CLUES:
+            logging.warning("Cannot discard at max clues")
+            raise InvalidMove("cannot discard at max clues")
+        discarded_card = self._current_hand.pop(turn.index)
+        logging.info(f"Player {self.current_player} discarded the card in slot {turn.index}, {str(discarded_card)}")
+        self.discarded_cards.append(discarded_card)
+        self._draw_card()
+
+        # Update information
+        logging.info(f"Player {self.current_player} Old Information: {[str(x) for x in self.current_information]}")
+        self.current_information.pop(turn.index)
+        self.current_information.insert(0, CardInformation())
+        logging.info(f"Player {self.current_player} New Information: {[str(x) for x in self.current_information]}")
+
+        self.clues += 1
 
     def _draw_card(self, index=None):
         """Draw a card for the `index`th player or the current player"""
@@ -168,8 +230,12 @@ class Board:
 
     def is_unique(self, card: Card) -> bool:
         """does a card need to be saved? these cards have a red exclamation point in the web version"""
-        original_count = {5: 1, 4: 2, 3: 2, 2: 2, 1: 3}[card.number] # original number of copies of that card
-        return (original_count - self.discarded_cards.count(card)) == 1
+        return (CARD_COUNT[card.number] - self.discarded_cards.count(card)) == 1
+
+    def relative_player(self, idx: int) -> int:
+        """Returns the absolute index of a player relative to the current player 
+           i.e. +1 for the next player, 0 for the current player, -1 for the previous player"""
+        return (self.current_player + idx) % self.num_players
 
     def __str__(self):
         newline = "\n"
@@ -179,7 +245,7 @@ class Board:
         Played cards ({self.score} / 25):
             {self.played_cards}
 
-        Hands:{newline}{indent(newline.join(" ".join(map(str, hand)) + (" <- current" if i == self.current_player else "") for i, hand in enumerate(self._hands)), " " * 12)}
+        Hands:{newline}{indent(newline.join(str(i) + ": " + " ".join(map(str, hand)) + (" <- current" if i == self.current_player else "") for i, hand in enumerate(self._hands)), " " * 12)}
 
         {self.strikes} strikes, {self.clues} clues, {f"{self.turns_left} turns remaining" if self.turns_left is not None else ""}
 

--- a/hanabi.py
+++ b/hanabi.py
@@ -64,15 +64,16 @@ class Board:
         self.strikes = 0
         self.clues = 8
 
+    @property
     def current_player(self):
         return (self.turn_index + self.starting_player) % self.num_players
 
     def evaluate(self, turn: Turn):
-        hand = self._hands[self.current_player()]
+        hand = self._hands[self.current_player]
 
         if isinstance(turn, Clue):
-            target = (self.current_player() + turn.target + 1) % self.num_players
-            logging.info(f"Player {self.current_player()} clued player {target} {turn.color or turn.number}")
+            target = (self.current_player + turn.target + 1) % self.num_players
+            logging.info(f"Player {self.current_player} clued player {target} {turn.color or turn.number}")
 
             if target == self.current_player:
                 raise InvalidMove("cannot clue self")
@@ -89,14 +90,14 @@ class Board:
             played_card = hand.pop(turn.index)
 
             if self.played_cards[played_card.color] == played_card.number - 1:
-                logging.info(f"Player {self.current_player()} played from slot {turn.index}, {str(played_card)} successfully")
+                logging.info(f"Player {self.current_player} played from slot {turn.index}, {str(played_card)} successfully")
                 self.played_cards[played_card.color] += 1
 
                 if played_card.number == 5:
                     self.clues += 1
                     self.clues = max(self.clues, 8)
             else:
-                logging.info(f"Player {self.current_player()} tried to play from slot {turn.index}, {str(played_card)}")
+                logging.info(f"Player {self.current_player} tried to play from slot {turn.index}, {str(played_card)}")
                 self.discarded_cards.append(played_card)
                 self.strikes += 1
 
@@ -106,7 +107,7 @@ class Board:
                 logging.warning("Cannot discard at max clues")
                 raise InvalidMove("cannot discard at max clues")
             discarded_card = hand.pop(turn.index)
-            logging.info(f"Player {self.current_player()} discarded the card in slot {turn.index}, {str(discarded_card)}")
+            logging.info(f"Player {self.current_player} discarded the card in slot {turn.index}, {str(discarded_card)}")
             self.discarded_cards.append(discarded_card)
             self._draw_card()
             self.clues += 1
@@ -124,7 +125,7 @@ class Board:
 
         if self._deck:
             new_card = self._deck.pop()
-            player = index if index is not None else self.current_player()
+            player = index if index is not None else self.current_player
             self._hands[player].insert(0, new_card)
         else:
             if self.turns_left is None:
@@ -138,15 +139,15 @@ class Board:
 
     def visible_hands(self) -> List[List[Card]]:
         """Other players' hands from the perspective of the current player"""
-        return self._hands[self.current_player() + 1:] + self._hands[:self.current_player()]
+        return self._hands[self.current_player + 1:] + self._hands[:self.current_player]
 
     def my_hand_clues(self) -> List[bool]:
         """Which cards in my hand are clued"""
-        return [card.clued for card in self._hands[self.current_player()]]
+        return [card.clued for card in self._hands[self.current_player]]
 
     def my_hand_size(self) -> int:
         """How many cards are in my hand"""
-        return len(self._hands[self.current_player()])
+        return len(self._hands[self.current_player])
 
     def __str__(self):
         newline = "\n"
@@ -156,7 +157,7 @@ class Board:
         Played cards ({self.score()} / 25):
             {self.played_cards}
 
-        Hands:{newline}{indent(newline.join(" ".join(map(str, hand)) + (" <- current" if i == self.current_player() else "") for i, hand in enumerate(self._hands)), " " * 12)}
+        Hands:{newline}{indent(newline.join(" ".join(map(str, hand)) + (" <- current" if i == self.current_player else "") for i, hand in enumerate(self._hands)), " " * 12)}
 
         {self.strikes} strikes, {self.clues} clues, {f"{self.turns_left} turns remaining" if self.turns_left is not None else ""}
 

--- a/hanabi.py
+++ b/hanabi.py
@@ -150,6 +150,13 @@ class Board:
            i.e. +1 for the next player, 0 for the current player, -1 for the previous player"""
         return (self.current_player + idx) % self.num_players
 
+    def cards_touched(self, clue: Clue) -> List[bool]:
+        """Returns a list of cards that will be touched by this clue"""
+        if clue.color:
+            return [card.color == clue.color for card in self.get_hand(clue.target)]
+        elif clue.number:
+            return [card.number == clue.number for card in self.get_hand(clue.target)]
+
     def evaluate(self, turn: Turn):
         """Processes the results of each players' turn"""
         if isinstance(turn, Clue):

--- a/hanabi.py
+++ b/hanabi.py
@@ -4,7 +4,6 @@ from textwrap import dedent, indent
 from typing import List, Union, Tuple, Set, Dict
 import random
 
-MAX_CLUES = 8
 
 # Turn
 @dataclass
@@ -134,6 +133,8 @@ class VariantDuck(VariantDefault):
             card_info.clued = True
     
 class Board:
+    MAX_CLUES = 8
+
     def __init__(self, num_players, seed=None, starting_player=0, variant=VariantDefault):
         self.num_players = num_players
         self.variant = variant
@@ -148,7 +149,7 @@ class Board:
         self.turn_index = 0
         self.turns_left: Optional[int] = None # None until the deck is exhausted, then counts down to 0
         self.strikes = 0
-        self.clues = MAX_CLUES
+        self.clues = Board.MAX_CLUES
 
         ### Hidden attributes. DO NOT ACCESS THESE ATTRIBUTES IN YOUR BOT ###
         self._card_info: List[List[CardInfo]] = [[] for _ in range(self.num_players)]
@@ -295,7 +296,7 @@ class Board:
 
             if played_card.number == 5:
                 self.clues += 1
-                self.clues = max(self.clues, MAX_CLUES)
+                self.clues = max(self.clues, Board.MAX_CLUES)
         else:
             logging.info(f"Player {self.current_player} tried to play from slot {card.index}, {str(played_card)}")
             self.discarded_cards.append(played_card)
@@ -310,7 +311,7 @@ class Board:
         logging.debug(f"Player {self.current_player} New Information: {[str(x) for x in self.current_info]}")
 
     def _discard_turn(self, card: Discard):
-        if self.clues == MAX_CLUES:
+        if self.clues == Board.MAX_CLUES:
             logging.warning("Cannot discard at max clues")
             raise InvalidMove("cannot discard at max clues")
         discarded_card = self._current_hand.pop(card.index)

--- a/main.py
+++ b/main.py
@@ -12,13 +12,8 @@ def run(board: Board, bots: List[BaseBot]):
 
     while not board.game_over:
         logging.info(str(board))
-
-        player = board.current_player
-        turn = bots[player].play()
-        for bot in bots:
-            bot.listen(player, turn)
+        turn = bots[board.current_player].play(board)
         board.evaluate(turn)
-
 
     logging.warning(f"Game is complete with a score of {board.score}")
     return board.score
@@ -43,11 +38,11 @@ if __name__ == "__main__":
     STARTING_PLAYER = 0
     TRIALS = 100
 
-    bot_type = ListenerBotMk2
+    bot_type = CheatingBot
 
     board = Board(NUM_PLAYERS, STARTING_SEED, STARTING_PLAYER)
 
-    bots = [bot_type(board, i) for i in range(NUM_PLAYERS)]
+    bots = [bot_type() for _ in range(NUM_PLAYERS)]
 
     scores = score_bot(board, bots, TRIALS, STARTING_SEED)
 

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ def run(bots, seed=None):
     board = Board(NUM_PLAYERS, seed)
 
     while not board.is_game_over():
-        turn = bots[board.current_player()].play(board)
+        turn = bots[board.current_player].play(board)
         board.evaluate(turn)
 
         logging.info(str(board))

--- a/main.py
+++ b/main.py
@@ -7,12 +7,11 @@ from hanabi import Board
 logging.basicConfig(level=logging.WARNING)
 # I misuse logging here. Debug is for debugging, info is for watching a single game, warning is for many runs of the bot
 
-def run(bots, seed=None):
+def run(board: Board, bots: List[BaseBot]):
     """Run a single game"""
-    board = Board(NUM_PLAYERS, seed)
 
     while not board.game_over:
-        turn = bots[board.current_player].play(board)
+        turn = bots[board.current_player].play()
         board.evaluate(turn)
 
         logging.info(str(board))
@@ -20,29 +19,35 @@ def run(bots, seed=None):
     logging.warning(f"Game is complete with a score of {board.score}")
     return board.score
 
-def score_bot(players: List[BaseBot], num_players=4, trials=100, starting_seed=None) -> List[int]:
+def score_bot(board: Board, players: List[BaseBot], trials=100, starting_seed=None) -> List[int]:
     """Get a bot's average score"""
 
     scores = []
 
     for i in range(trials):
         seed = None if starting_seed is None else starting_seed + i
-        scores.append(run(players, seed=seed))
+        scores.append(run(board, bots))
         for p in players:
             p.reset()
+        board.reset(seed)
 
     return scores
 
 if __name__ == "__main__":
     NUM_PLAYERS = 4
+    STARTING_SEED = 0
+    STARTING_PLAYER = 0
+    TRIALS = 100
 
-    # Score your bot on 100 runs
-    bot = CheatingBot
-    scores = score_bot([bot() for i in range(NUM_PLAYERS)], starting_seed=0)
-    final_result = (f"Bot {bot.__name__} completed {len(scores)} trials with an average score of {sum(scores) / len(scores)} " +
+    bot_type = CheatingBot
+
+    board = Board(NUM_PLAYERS, STARTING_SEED, STARTING_PLAYER)
+
+    bots = [bot_type(board, i) for i in range(NUM_PLAYERS)]
+
+    scores = score_bot(board, bots, TRIALS, STARTING_SEED)
+
+    final_result = (f"Bot {bot_type.__name__} completed {len(scores)} trials with an average score of {sum(scores) / len(scores)} " +
         f"(max: {max(scores)}, min: {min(scores)}, {scores.count(25)} perfect)")
     logging.warning(final_result)
     print(final_result)
-
-    # Test your bot once
-    # run([bot() for i in range(NUM_PLAYERS)], seed=0)

--- a/main.py
+++ b/main.py
@@ -11,14 +11,14 @@ def run(bots, seed=None):
     """Run a single game"""
     board = Board(NUM_PLAYERS, seed)
 
-    while not board.is_game_over():
+    while not board.game_over:
         turn = bots[board.current_player].play(board)
         board.evaluate(turn)
 
         logging.info(str(board))
 
-    logging.warning(f"Game is complete with a score of {board.score()}")
-    return board.score()
+    logging.warning(f"Game is complete with a score of {board.score}")
+    return board.score
 
 def score_bot(players: List[BaseBot], num_players=4, trials=100, starting_seed=None) -> List[int]:
     """Get a bot's average score"""

--- a/main.py
+++ b/main.py
@@ -11,12 +11,14 @@ def run(board: Board, bots: List[BaseBot]):
     """Run a single game"""
 
     while not board.game_over:
+        logging.info(str(board))
+
         player = board.current_player
         turn = bots[player].play()
+        for bot in bots:
+            bot.listen(player, turn)
         board.evaluate(turn)
-        (bot.listen(player, turn) for bot in bots)
 
-        logging.info(str(board))
 
     logging.warning(f"Game is complete with a score of {board.score}")
     return board.score
@@ -41,7 +43,7 @@ if __name__ == "__main__":
     STARTING_PLAYER = 0
     TRIALS = 100
 
-    bot_type = ClueBotImproved
+    bot_type = ListenerBot
 
     board = Board(NUM_PLAYERS, STARTING_SEED, STARTING_PLAYER)
 

--- a/main.py
+++ b/main.py
@@ -11,8 +11,10 @@ def run(board: Board, bots: List[BaseBot]):
     """Run a single game"""
 
     while not board.game_over:
-        turn = bots[board.current_player].play()
+        player = board.current_player
+        turn = bots[player].play()
         board.evaluate(turn)
+        (bot.listen(player, turn) for bot in bots)
 
         logging.info(str(board))
 
@@ -39,7 +41,7 @@ if __name__ == "__main__":
     STARTING_PLAYER = 0
     TRIALS = 100
 
-    bot_type = CheatingBot
+    bot_type = ClueBot
 
     board = Board(NUM_PLAYERS, STARTING_SEED, STARTING_PLAYER)
 

--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
     STARTING_PLAYER = 0
     TRIALS = 100
 
-    bot_types = [DumbBot, ClueBot, ClueBotImproved, ClueBotMk3, ClueBotAdvanced, BasicCheatingBot, CheatingBot]
+    bot_types = [DumbBot, ClueBot, ClueBotImproved, ClueBotMk3, ClueBotAdvanced, BasicCheatingBot, CheatingBot, LookaheadBot]
 
     for bot_type in bot_types:
         board = Board(NUM_PLAYERS, STARTING_SEED, STARTING_PLAYER, variant=VariantDuck)

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import logging
 from typing import List
 
 from bot import *
-from hanabi import Board
+from hanabi import Board, VariantDuck
 
 logging.basicConfig(level=logging.ERROR)
 # I misuse logging here. Debug is for debugging, info is for watching a single game, warning is for many runs of the bot
@@ -38,10 +38,10 @@ if __name__ == "__main__":
     STARTING_PLAYER = 0
     TRIALS = 100
 
-    bot_types = [DumbBot, ClueBot, ClueBotImproved, ClueBotMk3, BasicCheatingBot, CheatingBot]
+    bot_types = [DumbBot, ClueBot, ClueBotImproved, ClueBotMk3, ClueBotAdvanced, BasicCheatingBot, CheatingBot]
 
     for bot_type in bot_types:
-        board = Board(NUM_PLAYERS, STARTING_SEED, STARTING_PLAYER)
+        board = Board(NUM_PLAYERS, STARTING_SEED, STARTING_PLAYER, variant=VariantDuck)
 
         bots = [bot_type() for _ in range(NUM_PLAYERS)]
 

--- a/main.py
+++ b/main.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     STARTING_PLAYER = 0
     TRIALS = 100
 
-    bot_type = ListenerBot
+    bot_type = ListenerBotMk2
 
     board = Board(NUM_PLAYERS, STARTING_SEED, STARTING_PLAYER)
 

--- a/main.py
+++ b/main.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
     STARTING_PLAYER = 0
     TRIALS = 100
 
-    bot_type = ClueBot
+    bot_type = ClueBotImproved
 
     board = Board(NUM_PLAYERS, STARTING_SEED, STARTING_PLAYER)
 

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from typing import List
 from bot import *
 from hanabi import Board
 
-logging.basicConfig(level=logging.WARNING)
+logging.basicConfig(level=logging.ERROR)
 # I misuse logging here. Debug is for debugging, info is for watching a single game, warning is for many runs of the bot
 
 def run(board: Board, bots: List[BaseBot]):
@@ -38,15 +38,16 @@ if __name__ == "__main__":
     STARTING_PLAYER = 0
     TRIALS = 100
 
-    bot_type = CheatingBot
+    bot_types = [DumbBot, ClueBot, ClueBotImproved, ClueBotMk3, BasicCheatingBot, CheatingBot]
 
-    board = Board(NUM_PLAYERS, STARTING_SEED, STARTING_PLAYER)
+    for bot_type in bot_types:
+        board = Board(NUM_PLAYERS, STARTING_SEED, STARTING_PLAYER)
 
-    bots = [bot_type() for _ in range(NUM_PLAYERS)]
+        bots = [bot_type() for _ in range(NUM_PLAYERS)]
 
-    scores = score_bot(board, bots, TRIALS, STARTING_SEED)
+        scores = score_bot(board, bots, TRIALS, STARTING_SEED)
 
-    final_result = (f"Bot {bot_type.__name__} completed {len(scores)} trials with an average score of {sum(scores) / len(scores)} " +
-        f"(max: {max(scores)}, min: {min(scores)}, {scores.count(25)} perfect)")
-    logging.warning(final_result)
-    print(final_result)
+        final_result = (f"Bot {bot_type.__name__} completed {len(scores)} trials with an average score of {sum(scores) / len(scores)} " +
+            f"(max: {max(scores)}, min: {min(scores)}, {scores.count(25)} perfect)")
+        logging.warning(final_result)
+        print(final_result)


### PR DESCRIPTION
I reorganized the relationship between 'bot' and 'board' a bit to open up some possibilities for future improvements.
- All players are referred to by absolute index now
- Added a 'listen(Turn)' method to the bot API so that bots are aware of other bots turns in case they want to track internal state. 
- Implemented a more robust information tracking concept in the board, based around 'CardInformation' using sets to track remaining possibilities for any cards in players' hands. This should be robust enough to deal with regular hanabi as well as duck variant. 